### PR TITLE
Log a message if a scc is specified in the csv

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -62,6 +62,7 @@ func initializeChecks(ctx context.Context, p policy.Policy, cfg certification.Co
 				"",
 				&http.Client{Timeout: 60 * time.Second}),
 			),
+			operatorpol.NewSecurityContextConstraintsCheck(),
 		}, nil
 	case policy.PolicyContainer:
 		return []certification.Check{

--- a/certification/internal/policy/operator/scc_check.go
+++ b/certification/internal/policy/operator/scc_check.go
@@ -1,0 +1,122 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/bundle"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+)
+
+// SecurityContextConstraintsCheck evaluates the csv and logs a message if a non default security context constraint is
+// needed by the operator
+
+type SecurityContextConstraintsCheck struct {
+	customSCCSpecified  bool
+	builtInSCCSpecified bool
+}
+
+func getDefaultSCCs() []string {
+	return []string{"restricted", "privileged", "nonroot", "hostnetwork", "hostmount-anyuid", "hostaccess", "anyuid"}
+}
+
+func NewSecurityContextConstraintsCheck() *SecurityContextConstraintsCheck {
+	return &SecurityContextConstraintsCheck{
+		false,
+		false,
+	}
+}
+
+func (p *SecurityContextConstraintsCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
+	requestedSCCList, err := p.dataToValidate(ctx, bundleRef.ImageFSPath)
+	if err != nil {
+		return false, err
+	}
+
+	return p.validate(ctx, requestedSCCList)
+}
+
+func (p *SecurityContextConstraintsCheck) dataToValidate(ctx context.Context, imagePath string) ([]string, error) {
+	csvFilepath, err := bundle.GetCsvFilePathFromBundle(imagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	csvFileReader, err := os.Open(csvFilepath)
+	if err != nil {
+		return nil, err
+	}
+
+	requestedSccList, err := bundle.GetSecurityContextConstraints(ctx, csvFileReader)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract security context constraints from ClusterServiceVersion: %w", err)
+	}
+
+	return requestedSccList, nil
+}
+
+func (p *SecurityContextConstraintsCheck) validate(ctx context.Context, requestedSccList []string) (bool, error) {
+	defaultSccList := getDefaultSCCs()
+
+	if requestedSccList == nil || len(requestedSccList) == 0 {
+		log.Infof("No security context constraint was requested so using the default %s scc", defaultSccList[0])
+		return true, nil
+	}
+
+	if len(requestedSccList) != 1 {
+		return false, fmt.Errorf("only one scc should be requested at a time")
+	}
+
+	for _, defaultScc := range defaultSccList {
+		if requestedSccList[0] == defaultScc {
+			log.Infof("A built in default security context constraint %s was requested", defaultScc)
+			p.builtInSCCSpecified = true
+			return true, nil
+		}
+	}
+
+	log.Infof("A custom scc was specified: %s", requestedSccList[0])
+	p.customSCCSpecified = true
+	return true, nil
+}
+
+func (p *SecurityContextConstraintsCheck) Name() string {
+	return "SecurityContextConstraintsCheck"
+}
+
+func (p *SecurityContextConstraintsCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Evaluates the csv and logs a message if a non default security context constraint is needed by the operator",
+		Level:            "optional",
+		KnowledgeBaseURL: "https://redhat-connect.gitbook.io/certified-operator-guide/troubleshooting-and-resources/sccs", // Placeholder
+		CheckURL:         "https://redhat-connect.gitbook.io/certified-operator-guide/troubleshooting-and-resources/sccs", // Placeholder
+	}
+}
+
+func (p *SecurityContextConstraintsCheck) Help() certification.HelpText {
+	if p.customSCCSpecified {
+		return certification.HelpText{
+			Message: "A custom security context constraint was detected in the csv. " +
+				"Please see the operators documentation for details.",
+			Suggestion: "A custom security context constraint may need to be applied by a cluster admin.",
+		}
+	}
+
+	if p.builtInSCCSpecified {
+		return certification.HelpText{
+			Message: "A built in default security context constraint was detected in the csv. " +
+				"Please see the operators documentation for details.",
+			Suggestion: "No action needed.",
+		}
+	}
+
+	return certification.HelpText{
+		Message: "The SecurityContextConstraintsCheck logs a message if the operator requests a " +
+			"security context constraint. Please review the operators documentation to see if this is needed.",
+		Suggestion: "Check if the operator requests a security context constraint in its csv",
+	}
+}
+

--- a/certification/internal/policy/operator/scc_check_test.go
+++ b/certification/internal/policy/operator/scc_check_test.go
@@ -1,0 +1,117 @@
+package operator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+)
+
+var _ = Describe("SecurityContextConstraintsCheck", func() {
+	const (
+		manifestsDir                  = "manifests"
+		clusterServiceVersionFilename = "myoperator.clusterserviceversion.yaml"
+		defaultSCC                    = "\n      clusterPermissions:\n      - rules:\n        - apiGroups:\n          - security.openshift.io\n          resources:\n          - securitycontextconstraints\n          resourceNames:\n          - anyuid\n          verbs:\n          - use\n        serviceAccountName: my-operand\n"
+		customSCC                     = "\n      clusterPermissions:\n      - rules:\n        - apiGroups:\n          - security.openshift.io\n          resources:\n          - securitycontextconstraints\n          resourceNames:\n          - custom\n          verbs:\n          - use\n        serviceAccountName: my-operand\n"
+		multipleSCC                   = "\n      clusterPermissions:\n      - rules:\n        - apiGroups:\n          - security.openshift.io\n          resources:\n          - securitycontextconstraints\n          resourceNames:\n          - anyuid\n          - nonroot\n          verbs:\n          - use\n        serviceAccountName: my-operand\n"
+		noSCC                         = "\n"
+	)
+	var (
+		securityContextConstraintsCheck SecurityContextConstraintsCheck
+		imageRef           certification.ImageReference
+		csvContents        = buildCsvContent(noSCC)
+	)
+	AssertMetaData(&securityContextConstraintsCheck)
+	BeforeEach(func() {
+		securityContextConstraintsCheck = *NewSecurityContextConstraintsCheck()
+		tmpDir, err := os.MkdirTemp("", "scc-check-bundle-*")
+		Expect(err).ToNot(HaveOccurred())
+		imageRef.ImageFSPath = tmpDir
+		DeferCleanup(os.RemoveAll, tmpDir)
+		err = os.Mkdir(filepath.Join(tmpDir, manifestsDir), 0o755)
+		Expect(err).ToNot(HaveOccurred())
+		err = os.WriteFile(filepath.Join(tmpDir, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	When("given a csv with a default scc", func() {
+		It("should succeed", func() {
+			csvContents := buildCsvContent(defaultSCC)
+			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
+			result, err := securityContextConstraintsCheck.Validate(context.TODO(), imageRef)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+			Expect(securityContextConstraintsCheck.Help().Message).To(ContainSubstring("default"))
+		})
+	})
+	When("given a csv with a custom scc", func() {
+		It("should succeed", func() {
+			csvContents := buildCsvContent(customSCC)
+			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
+			result, err := securityContextConstraintsCheck.Validate(context.TODO(), imageRef)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+			Expect(securityContextConstraintsCheck.Help().Message).To(ContainSubstring("custom"))
+		})
+	})
+	When("given a csv with a multiples sccs", func() {
+		It("should fail", func() {
+			csvContents := buildCsvContent(multipleSCC)
+			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
+			result, err := securityContextConstraintsCheck.Validate(context.TODO(), imageRef)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+	When("there is no CSV", func() {
+		It("should fail", func() {
+			Expect(os.RemoveAll(imageRef.ImageFSPath)).To(Succeed())
+			result, err := securityContextConstraintsCheck.Validate(context.TODO(), imageRef)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+	When("the CSV is malformed", func() {
+		It("should fail", func() {
+			csvContents := `kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+spec: malformed
+`
+			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
+			result, err := securityContextConstraintsCheck.Validate(context.TODO(), imageRef)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+	When("no scc is specfied in csv", func() {
+		It("should still pass", func() {
+			csvContents := buildCsvContent(noSCC)
+			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
+			result, err := securityContextConstraintsCheck.Validate(context.TODO(), imageRef)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+})
+
+func buildCsvContent(sccBlock string) string {
+	return `kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+spec:
+  install:
+    spec:
+      deployments:
+      - spec:
+          template:
+            spec:
+              containers:
+              - image: registry.example.io/foo/bar@sha256:f000432f07cd187469f0310e3ed9dcf9a5db2be14b8bab9c5293dd1ee8518176
+                name: the-operator` + sccBlock +
+		`relatedImages:
+  - name: the-operator
+    image: registry.example.io/foo/bar@sha256:f000432f07cd187469f0310e3ed9dcf9a5db2be14b8bab9c5293dd1ee8518176
+  - name: the-proxy
+    image: registry.example.io/foo/proxy@sha256:5e33f9d095952866b9743cc8268fb740cce6d93439f00ce333a2de1e5974837e`
+}


### PR DESCRIPTION
- replace the invalid image plus with a hyphen
- Updated go version to v1.17 in Vagrantfile    - Fixes make build issue  #397
- Use qemu action instead of apt install
- Parameterize the IMAGE_REGISTRY in Actions
- default pyxis host
- Add code for submitting a certification to Pyxis
- Implement RunnableContainerCheck
- Add Unit tests for RunnableContainerCheck
- Enable WaitContainer to timeout if the container does not reach the running state
- Make GetProject an exported method of PyxisEngine
- Changes uses of make to be more idiomatic Go (#412)
- After a certain point in the command, silence the usage output
- add a reusable multiarch manifest action (#414)
- implementing submit flag and saving cert image info and rpm manifest information to disk to be used later in the submission to pyxis
- Implement RunAsSystemContainer Check
- Move the defer statement to after error checks
- refacotring to make project id and api token required flags, also making docker config a required flag conditional on the submit flag's presence
- Use the submit variable where possible
- Code cleanup
- Fixing a bug in upload of binaries to the release
- handling non-200 responses from all pyxis calls (#419)
- Use a more strict 'go fmt'
- Add image_id to the test results (#423)
- Add RunAsSystemContainer check to the scratch image policy (#429)
- Add a doc describing how to find uncompressed layer IDs
- Simplify the handling of the API token (#427)
- Fix generic check formatting
- Add layer information to the results
- displaying response information to the user after results have been submitted, and providing them a URL where they can monitor the results (#432)
- update gh release action so preflight can support alpha, beta and rc releases
- Limit the usage of log.Info (#439)
- Dedupe the test results structs a bit (#441)
- making fixes to the data that we marshal and send to pxyis, these changes are the bare minimum changes to get be able to submit results
- adding back omitempty in TestResults struct which got accidentally dropped in a rebase
- Disable runnable checks for now
- Update current list of reviewers
- removing --submit check when writing image config and rpm manifest to disk (#450)
- Add PGP key id to the RPM manifest (#449)
- Add a flag to specify an image as a scratch image
- adding in a call to pyxis getImage so preflight can run multiple times if an API error happens mid-run
- adding recipes for `check container`
- match catalog url and connect url to support running preflight in lower environments
- Check for sqlite RPM database (#456)
- adding in repositories information for create image pyxis call
- Fix typo - redundant space in API parameter
- Pass docker config to the results upload
- Add some useful fields to ImageReference
- making certImage.certified match testResults.passed (#462)
- updating readme with the latest acceptable commands
- adding in scan results url to output and changing to the mongo db _id to be displayed to the user
- using crane's name package to determine the format of the registry instead of hard coding (#468)
- Refactor url building for DRY
- added in layers array into ParsedData struct since this is required for Clair scans (#476)
- Upgrade ginkgo test suite to v2
- Reorder the steps in the go action
- adding in createArtifacts method so we can send pyxis the preflight.log (#473)
- added base64 contents to artifacts
- removing options from cran ListTags call. crane ends up using options.auth to successfully call `/list/tags` for registries with auth (#457)
- Check for modified base layer files (#483)
- Update go-rpmdb to the latest downstream
- changing parsedData.Layers to come from the imageInfo.Manifest instead of config.RootFS.DiffIDs (#484)
- Revert "Update go-rpmdb to the latest downstream"
- Fail multi-arch-build on any failure
- Ignore multi-arch binaries from git
- Write project id back to viper if modified (#492)
- updating gitignore to include check container cert-image and rpm-mainfest json files (#493)
- updated comment for HasModifiedFilesCheck
- check image under test for a certified uncompressed top layer id
- using registry/repository/tag information from imageRef struct instead of calling crane.NewTag which fails for shas (#501)
- Simplify Pyxis Submit call (#498)
- Introduce context param throughout the codebase
- updating support cmd to only add pull_request_url for `Operator Bundle Image` project types
- add release version to the binaries localted on github releases page
- fix url for call to search for layers
- Make pyxis tests more robust
- Add a license (#512)
- Update errors.go (#511)
- Set a non-root user
- Update Dockerfile
- log pyxis layer check request
- Force use of prod pyxis for Based On UBI check
- Use the default pyxis host for BasedOnUBI (#520)
- Populate container fields in cert project
- Add Dockerfile for another failure scenario
- Change go-get-tool to go-install-tool
- Rename pyxisEngine to pyxisClient (#526)
- fix zero-length base layer bug and add comments
- remove irrelevant comments
- logging overall results status of pass or fail in both container and operator checks
- Update go-rpmdb to latest midstream main (#531)
- Fix source rpm name parsing (#532)
- Utilize built-in cache of crane library (#534)
- updating RunAsNonRoot logs to be info level and provide more details to the user (#537)
- Fix nonroot home directory permissions (#538)
- Use graphql for CheckRedHatLayers
- Reverting user changes
- fix typo in certification-project-id flag
- build make target only looks for the preflight binary on build (#550)
- no longer throw exceptions back for RPM manifests, and always submit results to pyxis even if we do not have RPM manifest files (#540)
- Move OsContentType to CertProjectContainer
- document workflow for submitting container check results to red hat
- adding clarity to logs when GetPackageList is called
- clarify the graphql layer checking logic
- Remove redundant alpha tag from the displayed version
- Make the pulling of the project to check for scratch optional
- convert submission logic to a builder-ish style
- HasNoProhibitedPackages check has an incorrect name. Fix it.
- Simplify the install of go tools
- Add environment variables to --help output (#565)
- Prefer the usage of pyxis env instead of pyxis host
- Refactor and simplify some of the file reading
- adding in PrivilegedContainerPolicy which is to be used to exclude RunAsNonRoot check for projects that have Host level access set to `Privileged` in connect project setup
- removing pyxis host and api key from viper in init since they are gathered in different way now
- updating recipes file to include a way to run `check container` via podman (#574)
- updating vagrant file to use fedora 35 (#575)
- Make the Connect URLs match the environment given
- updating check container check url in all tests to point to official 4.9 cert docs (#581)
- updating check container recipe to add in support for private registries (#583)
- adding in PFLT_CERTIFICATION_PROJECT_ID to CONFIG info
- updating vagrant file to change the port so that this vm and crc can run at the same time
- Switch to a go-release-action for building binaries
- Bump go-containerregistry to HEAD as of 2022-04-28 (#589)
- Copy release images to redhat-isv on quay (#591)
- Fix a data race exposed by race checker
- Use --docker-config for crane if specified
- Run tests on release branches
- Fix docker-config flag to come from persistent flags, not flags. (#598)
- remove extra return and add test coverage to pyxis input builder
- add preflight-specific labels to the resulting container image
- updating a few of the help texts based on a few issues that partners have had with the check container cmd (#604)
- move update logic into `started` since we should only care about updating net new projects all other updates are taken care of by backend systems (#603)
- Increase Pyxis test coverage
- Refactor Pyxis builder to use an io.Reader
- increase test coverage of version package
- Increase coverage of the internal/bundle package (#623)
- increase artifacts test coverage
- Refactor hasUniqueTagCheck to get rid of CraneEngine
- Fix the coverage of the certification package (#629)
- Increase coverage of the runtime assets package (#628)
- always update the project no matter the status to ensure the dockerconfig preflight used to pull the image is the same as what backend systems will use
- Enhance test coverage for internal/engine package
- ioutil calls deprecated
- Refactor Openshift engine to increase testability
- Fix typos
- Refactor OpenShift client wrapper to its own package
- normalize docker registries to `docker.io` for the cert image (#651)
- Fix #366, Expose All Optional Configurations in --help
- mend
- Remove errors package
- Report coverage in a PR comment (#667)
- Normalize error handling (#654)
- Enable coverage for main branch (#672)
- Fixup error handling in runtime package (#668)
- Update container certification doc url #648
- Encapsulate authn errors
- Pass a noop logger to crane fake registry
- Fix errors and logs in internal engine package
- Do not expose all errors from rpm package
- Fix up bundle errors
- Fix errors and return values
- Fix a panic in DeployableByOLM
- Remove unused checks
- Produce errors more consistently in operator policy package
- Improve coverage and tidy up errors
- Tidy up error handling in container package
- enforce a single point of configuration
- fix bug in error result text
- Add support for retrieving the freshness grade of an image
- add e2e variant that modifies common environment variables
- Add FindImagesByDigest to the pyxis client
- Add capability to extract images from a bundle
- add list-checks and remove --list-checks
- add runtime-assets testing
- make certificationInput a public type to aid in testing
- add function to get formatter by name and move default val
- add new ifaces for cmd execution with implementations
- updating gh actions to login to a given registry before we try to execute any action on said registry
- updating to latest version of go-rpmdb that includes breaking changes from upstream
- add interface-driven preflightCheck func
- refactor check_container to use preflightCheck, and enable tests
- refactor support command to remove promptui, and add test coverage
- remove flaky docker-config test
- updating containerCertificationSubmitter to only read the docker file from disk if one is provided and adding a warning for public dockerhub registries if no file is provided
- fix bug with undefined default formatter
- remove extraneous defined error
- add junitxml formatter test
- Increase coverage of the engine package
- adding in PFLT_JUNIT to the configs md for clarity
- test the pyxis host lookup behavior
- refactor check operator to leverage interface-based execution
- fix bug in derived runtime config where values were not populated from parameter
- Refactor operatorsdk and add some unit tests
- Increase coverage in the openshift package
- Bump go-rpmdb and go-containerregistry deps
- add a few tests for the modified files check
- add tests confirming check metadata is never empty
- Extract the metadata tests to a separate function
- Bump go-rpmdb to latest
- fix keychain resolution for docker.io
- Fallback to cli tag in container HasUniqueTag test
- wait for layer file processing to complete before proceeding
- inform the user of tag and digest binding semantics for container cert
- Add a check for certified images in the CSV
- Add related images check
- re-adds basedOnUBI check to root policy exception
- add check that logs a message if a scc is used
